### PR TITLE
Add Linux support for INTERCONNECT from Klayout

### DIFF
--- a/klayout_dot_config/python/SiEPIC/lumerical/interconnect.py
+++ b/klayout_dot_config/python/SiEPIC/lumerical/interconnect.py
@@ -144,14 +144,16 @@ def Setup_Lumerical_KLayoutPython_integration(verbose=False):
 
 def INTC_commandline(filename2):
   print ("Running Lumerical INTERCONNECT using the command interface.")
-  import sys, os
+  import sys, os, string
   
   if sys.platform.startswith('linux'):
+    import subprocess
     # Linux-specific code here...
-    if string.find(version,"2.") > -1:
-      import commands
-      print("Running INTERCONNECT")
-      commands.getstatusoutput('/opt/lumerical/interconnect/bin/interconnect -run %s' % filename2)
+    print("Running INTERCONNECT")
+    # Location of INTERCONNECT program (this found from RPM installation)
+    file_path = '/opt/lumerical/interconnect/bin/interconnect'
+    subprocess.Popen([file_path, '-run', filename2])
+      
   
   elif sys.platform.startswith('darwin'):
     # OSX specific

--- a/klayout_dot_config/python/SiEPIC/lumerical/load_lumapi.py
+++ b/klayout_dot_config/python/SiEPIC/lumerical/load_lumapi.py
@@ -29,6 +29,13 @@ def load_lumapi(verbose=False):
       path_intc = "/Applications/Lumerical/INTERCONNECT/INTERCONNECT.app/Contents/API/Python"
       if os.path.exists(path_intc):
         path = path_intc
+    elif platform.system() == 'Linux':
+      path_fdtd = "/opt/lumerical/fdtd/api/python"
+      if os.path.exists(path_fdtd):
+        path = path_fdtd
+      path_intc = "/opt/lumerical/interconnect/api/python"
+      if os.path.exists(path_intc):
+        path = path_intc
     elif platform.system() == 'Windows': 
       path_fdtd = "C:\\Program Files\\Lumerical\\FDTD Solutions\\api\\python"
       if os.path.exists(path_fdtd):
@@ -173,6 +180,12 @@ def load_lumapi(verbose=False):
       
   # Windows
   elif platform.system() == 'Windows': 
+    if os.path.exists(path):
+      if not path in sys.path:
+        sys.path.append(path) # windows
+      os.chdir(path) 
+  # Linux    
+  elif platform.system() == 'Linux': 
     if os.path.exists(path):
       if not path in sys.path:
         sys.path.append(path) # windows


### PR DESCRIPTION
Hi,

This commit allows simulations to work with INTERCONNECT when running KLayout in Linux.  It points to the default installation location from the Linux RPM given from Lumerical.